### PR TITLE
[FE] All MxMs 페이지 추가

### DIFF
--- a/src/components/AllClothes.vue
+++ b/src/components/AllClothes.vue
@@ -34,7 +34,7 @@ export default {
     }
   },
   created () {
-    axios.get('http://localhost:8000/clothes/')
+    axios.get('http://localhost:8000/api/clothes/')
     .then(res => {
       this.clothes = res.data
     })

--- a/src/components/AllMxMs.vue
+++ b/src/components/AllMxMs.vue
@@ -1,20 +1,48 @@
-<!-- Placeholder -->
-
 <template>
-  <div class="hello">
-    <h1>{{ msg }}</h1>
-  </div>
+  <section class="hero">
+    <div class="hero-title">
+      <h1 class="title">
+        All MxMs
+      </h1>
+      <h2 class="subtitle">
+        Check your MxM
+      </h2>
+      <br/>
+    </div>
+
+    <div class="container">
+      <div id="allMxMs-list-wrapper">
+        <ul>
+          <li v-for="mxm in mxms">
+            MxM #{{ mxm.id }}<br/>
+            clothes id: {{ mxm.clothes }}<br/>
+            when created? {{ mxm.created_time }}
+            <br/><br/>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
 </template>
 
 <script>
+import axios from 'axios'
 export default {
-  data () {
+  data: function () {
     return {
-      msg: 'All MxMs'
+      mxms: []
     }
+  },
+  created () {
+    axios.get('http://localhost:8000/api/mxms/')
+    .then(res => {
+      this.mxms = res.data
+    })
+    .catch(error => console.log(error))
   }
 }
 </script>
+
 
 <style scoped>
 h1 {

--- a/src/components/AllMxMs.vue
+++ b/src/components/AllMxMs.vue
@@ -5,7 +5,7 @@
         All MxMs
       </h1>
       <h2 class="subtitle">
-        Check your MxM
+        Check your MxMs
       </h2>
       <br/>
     </div>

--- a/test/unit/specs/AllMxMs.spec.js
+++ b/test/unit/specs/AllMxMs.spec.js
@@ -1,0 +1,38 @@
+import Vuex from 'vuex'
+import VueRouter from 'vue-router'
+import { shallow, createLocalVue } from 'vue-test-utils'
+import AllMxMs from '@/components/AllMxMs'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+localVue.use(VueRouter)
+
+describe('AllMxMs.vue', () => {
+  let store
+  let router
+
+  beforeEach(() => {
+    router = new VueRouter()
+    store = new Vuex.Store()
+  })
+
+  it('is instance of Vue', () => {
+    const wrapper = shallow(AllMxMs, { localVue, store, router })
+    expect(wrapper.isVueInstance()).toBe(true)
+  })
+
+  it('has 1 hero section', () => {
+    const wrapper = shallow(AllMxMs, { localVue, store, router })
+    expect(wrapper.findAll('.hero').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('has title named All MxMs', () => {
+    const wrapper = shallow(AllMxMs, { localVue, store, router })
+    expect(wrapper.find('.title').text()).toBe('All MxMs')
+  })
+
+  it('has subtitle named Check your MxMs', () => {
+    const wrapper = shallow(AllMxMs, { localVue, store, router })
+    expect(wrapper.find('.subtitle').text()).toBe('Check your MxMs')
+  })
+})

--- a/test/unit/specs/Closet.spec.js
+++ b/test/unit/specs/Closet.spec.js
@@ -3,6 +3,7 @@ import VueRouter from 'vue-router'
 import { shallow, createLocalVue } from 'vue-test-utils'
 import Closet from '@/components/Closet'
 import AllClothes from '@/components/AllClothes'
+import ClothesDetail from '@/components/ClothesDetail'
 import AllMxMs from '@/components/AllMxMs'
 import closet from '@/store/modules/closet'
 import * as types from '@/store/types'
@@ -32,6 +33,10 @@ describe('Closet.vue', () => {
             {
               path: 'clothes/all',
               component: AllClothes
+            },
+            {
+              path: 'clothes/detail',
+              component: ClothesDetail
             },
             {
               path: 'mxm/all',

--- a/test/unit/specs/ClothesDetail.spec.js
+++ b/test/unit/specs/ClothesDetail.spec.js
@@ -1,0 +1,23 @@
+import Vuex from 'vuex'
+import VueRouter from 'vue-router'
+import { shallow, createLocalVue } from 'vue-test-utils'
+import ClothesDetail from '@/components/ClothesDetail'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+localVue.use(VueRouter)
+
+describe('ClothesDetail.vue', () => {
+  let store
+  let router
+
+  beforeEach(() => {
+    router = new VueRouter()
+    store = new Vuex.Store()
+  })
+
+  it('is instance of Vue', () => {
+    const wrapper = shallow(ClothesDetail, { localVue, store, router })
+    expect(wrapper.isVueInstance()).toBe(true)
+  })
+})


### PR DESCRIPTION
- All MxMs 페이지 추가하였습니다.
- MxM의 경우 어떤 데이터를 표시해야할지 확정된 게 없는 것 같아서 일단 id, clothes, created_time이 나타나도록 하였습니다.
- 백엔드 data를 받아오는 컴포넌트 테스트를 어떻게 해야할지를 아직 못찾아서 계속 커버리지가 떨어지네요. 다음 분기에 보완하도록 하겠습니다.
- ClothesDetail의 경우 테스트 자체는 통과하는데 결과에서는 다르게 나오네요. 다시 확인해보겠습니다.

<All MxMs>

![2018-05-13 19-03-58](https://user-images.githubusercontent.com/22138081/39966100-28146802-56e1-11e8-800b-ffe53dc35b3c.png)


<npm run unit 결과>
![npm run unit](https://user-images.githubusercontent.com/22138081/39966109-55807efc-56e1-11e8-9548-d2210a984726.jpg)

